### PR TITLE
Django 1.9+ bulk insert compatibility fix.

### DIFF
--- a/lib/mysql/connector/django/operations.py
+++ b/lib/mysql/connector/django/operations.py
@@ -218,9 +218,15 @@ class DatabaseOperations(BaseDatabaseOperations):
     def max_name_length(self):
         return 64
 
-    def bulk_insert_sql(self, fields, num_values):
-        items_sql = "({0})".format(", ".join(["%s"] * len(fields)))
-        return "VALUES " + ", ".join([items_sql] * num_values)
+    if django.VERSION < (1, 9):
+        def bulk_insert_sql(self, fields, num_values):
+            items_sql = "({0})".format(", ".join(["%s"] * len(fields)))
+            return "VALUES " + ", ".join([items_sql] * num_values)
+    else:
+        def bulk_insert_sql(self, fields, placeholder_rows):
+            placeholder_rows_sql = (", ".join(row) for row in placeholder_rows)
+            values_sql = ", ".join("({0})".format(sql) for sql in placeholder_rows_sql)
+            return "VALUES " + values_sql
 
     if django.VERSION < (1, 8):
         def year_lookup_bounds(self, value):


### PR DESCRIPTION
- Support database backend api change introduced in Django 1.9 for
  bulk_insert_sql method.